### PR TITLE
Make gem compatible with ougai 2.0

### DIFF
--- a/ougai-formatters-inline_readable.gemspec
+++ b/ougai-formatters-inline_readable.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  spec.add_runtime_dependency "ougai", "~> 2.0"
+  spec.add_runtime_dependency "ougai"
   spec.add_runtime_dependency "awesome_print", "~> 1.8"
 end

--- a/ougai-formatters-inline_readable.gemspec
+++ b/ougai-formatters-inline_readable.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  spec.add_runtime_dependency "ougai", "~> 1.5"
+  spec.add_runtime_dependency "ougai", "~> 2.0"
   spec.add_runtime_dependency "awesome_print", "~> 1.8"
 end


### PR DESCRIPTION
Ougai version 2.0 (https://github.com/tilfin/ougai/releases/tag/v2.0.0) was released on Feb 20, 2021.
This change bumps up the runtime dependency so that it can be used with 2.x versions. 
Some basic manual testing has been done to confirm that nested fields work with the formatter. That was the PR that caused the 2.x version see https://github.com/tilfin/ougai/pull/118